### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -6,16 +6,16 @@ on:
     branches:
       - 'main'
 
-jobs:
-  review-dependabot-pr:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - uses: otto-ec/m4-delivery_gh_actions/dependabot-review@eb02d63eda71cdea9d6089fd44191dabaf074f51
-        if: github.event.pull_request.user.login == 'dependabot[bot]'
-        with:
-          auto-approve: minor
-          auto-merge-type: squash
-          token: ${{ secrets.EC_TOKEN }}
+#jobs:
+#  review-dependabot-pr:
+#    runs-on: ubuntu-latest
+#    permissions:
+#      pull-requests: write
+#      contents: write
+#    steps:
+#      - uses: otto-ec/m4-delivery_gh_actions/dependabot-review@eb02d63eda71cdea9d6089fd44191dabaf074f51
+#        if: github.event.pull_request.user.login == 'dependabot[bot]'
+#        with:
+#          auto-approve: minor
+#          auto-merge-type: squash
+#          token: ${{ secrets.EC_TOKEN }}

--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -1,4 +1,6 @@
 name: Purge workflow runs
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -1,6 +1,8 @@
 name: Purge workflow runs
 permissions:
   contents: read
+  actions: write
+  
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/otto-de/purge-deprecated-workflow-runs/security/code-scanning/3](https://github.com/otto-de/purge-deprecated-workflow-runs/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Based on the functionality of the `otto-de/purge-deprecated-workflow-runs` action, the workflow likely only requires `contents: read` permissions to list and manage workflow runs. We will add this minimal permission at the workflow level to ensure all jobs inherit it unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
